### PR TITLE
GPII-1519: Updating the package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "first-discovery",
+  "name": "gpii-first-discovery",
   "description": "A preferences editor tool that helps users discovery their initial preferences.",
   "version": "0.1.0-SNAPSHOT",
   "author": "GPII",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gpii-first-discovery",
   "description": "A preferences editor tool that helps users discovery their initial preferences.",
-  "version": "0.1.0-SNAPSHOT",
+  "version": "1.0.0",
   "author": "GPII",
   "bugs": "https://issues.gpii.net",
   "homepage": "http://gpii.net",
@@ -20,7 +20,7 @@
   "repository": "git@github.com:GPII/first-discovery.git",
   "main": "",
   "engines": {
-    "node": ">=0.1.9"
+    "node": ">=0.8.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Updated the package name to use the gpii- prefix.

https://issues.gpii.net/browse/GPII-1519